### PR TITLE
Fixed endless loop in detail for partialy initialized magnet

### DIFF
--- a/shift.js
+++ b/shift.js
@@ -1098,6 +1098,9 @@ function renderPieces( pieces, cell ) {
   canvas.width = w;
 
   var ppp = globals.currentTorrent.pieceCount / w; // pieceCount per pixel
+  if( ppp == 0 ) {
+    return canvas;
+  }
 
   var ctx = canvas.getContext( "2d" );
   ctx.strokeStyle = globals.piecesColor;


### PR DESCRIPTION
Issue: displaying details of torrent not yet fully initialized from a magnet link will result in endless loop during pieces rendering.
this change does fix that issue